### PR TITLE
fix for #22

### DIFF
--- a/src/items/card.jl
+++ b/src/items/card.jl
@@ -26,7 +26,15 @@ function to_html(deck::Deck)
         <li>
             <div class="cardx">
                 <span class="any $(color[1])">$(c.first)</span>
+        """
+        if !isempty(c.second)
+            str *=
+            """
                 <span class="second any $(color[2])">$(c.second)</span>
+            """
+        end
+        str *=
+        """
             </div>
             <div class="description">
                 <p class="cardtitle">$(c.title)</p>


### PR DESCRIPTION
This should allow the second field in cards to be optional, given that no information is given in the second element of the struct `Card`(*i.e.* an empty string `""` is used).

idk if this was the planned behavior for #22 ; if yes, feel free to accept the PR :)

(thanks for the work, btw!)